### PR TITLE
[대규모 시스템 설계] 게시글 목록 API - 무한 스크롤 구현 실습

### DIFF
--- a/large-scale-board/service/article/src/main/java/april2nd/board/article/controller/ArticleController.java
+++ b/large-scale-board/service/article/src/main/java/april2nd/board/article/controller/ArticleController.java
@@ -8,6 +8,8 @@ import april2nd.board.article.service.response.ArticleResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 public class ArticleController {
@@ -24,6 +26,14 @@ public class ArticleController {
             @RequestParam("page") Long page,
             @RequestParam("pageSize") Long pageSize) {
         return articleService.readAll(boardId, page, pageSize);
+    }
+
+    @GetMapping("/v1/articles/infinite-scroll")
+    public List<ArticleResponse> readAllInfiniteScroll(
+            @RequestParam("boardId") Long boardId,
+            @RequestParam("pageSize") Long pageSize,
+            @RequestParam(value = "lastArticleId", required = false) Long lastArticleId) {
+        return articleService.readAllInfiniteScroll(boardId, pageSize, lastArticleId);
     }
 
     @PostMapping("/v1/articles")

--- a/large-scale-board/service/article/src/main/java/april2nd/board/article/repository/ArticleRepository.java
+++ b/large-scale-board/service/article/src/main/java/april2nd/board/article/repository/ArticleRepository.java
@@ -38,4 +38,32 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
             @Param("boardId") Long boardId,
             @Param("limit") Long limit
     );
+
+    @Query(
+            value = "select article.article_id, article.title, article.content, article.board_id, article.writer_id, " +
+                    "article.created_at, article.modified_at " +
+                    "from article " +
+                    "where board_id = :boardId " +
+                    "order by article_id desc limit :limit ",
+            nativeQuery = true
+    )
+    List<Article> findAllInfiniteScroll(
+            @Param("boardId") Long boardId,
+            @Param("limit") Long limit
+    );
+
+    @Query(
+            value = "select article.article_id, article.title, article.content, article.board_id, article.writer_id, " +
+                    "article.created_at, article.modified_at " +
+                    "from article " +
+                    "where board_id = :boardId " +
+                    "and article_id < :lastArticleId " +
+                    "order by article_id desc limit :limit ",
+            nativeQuery = true
+    )
+    List<Article> findAllInfiniteScroll(
+            @Param("boardId") Long boardId,
+            @Param("limit") Long limit,
+            @Param("lastArticleId") Long lastArticleId
+    );
 }

--- a/large-scale-board/service/article/src/main/java/april2nd/board/article/service/ArticleService.java
+++ b/large-scale-board/service/article/src/main/java/april2nd/board/article/service/ArticleService.java
@@ -11,6 +11,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class ArticleService {
@@ -58,5 +60,13 @@ public class ArticleService {
                         PageLimitCalculator.calculatePageLimit(page, pageSize, 10L)
                 )
         );
+    }
+
+    public List<ArticleResponse> readAllInfiniteScroll(Long boardId, Long pageSize, Long lastArticleId) {
+        List<Article> articles = lastArticleId == null ?
+                articleRepository.findAllInfiniteScroll(boardId, pageSize) :
+                articleRepository.findAllInfiniteScroll(boardId, pageSize, lastArticleId);
+
+        return articles.stream().map(ArticleResponse::from).toList();
     }
 }

--- a/large-scale-board/service/article/src/test/java/april2nd/board/article/api/ArticleApiTest.java
+++ b/large-scale-board/service/article/src/test/java/april2nd/board/article/api/ArticleApiTest.java
@@ -4,11 +4,16 @@ import april2nd.board.article.service.response.ArticlePageResponse;
 import april2nd.board.article.service.response.ArticleResponse;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.web.client.RestClient;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@Slf4j
 public class ArticleApiTest {
     RestClient restClient = RestClient.create("http://localhost:9000");
 
@@ -73,6 +78,24 @@ public class ArticleApiTest {
     void readAllTest() {
         restClient.get().uri("/v1/articles?boardId=1&pageSize=30&page=50000")
                 .retrieve().body(ArticlePageResponse.class);
+    }
+
+    @Test
+    void readAllInfiniteScrollTest() {
+        List<ArticleResponse> firstPage = restClient.get().uri("/v1/articles/infinite-scroll?boardId=1&pageSize=30")
+                .retrieve().body(new ParameterizedTypeReference<List<ArticleResponse>>() {
+                });
+
+        Long lastArticleId = firstPage.getLast().getArticleId();
+        log.info("Last Article Id >>>>>>>>  = " + lastArticleId);
+
+        List<ArticleResponse> secondPage = restClient.get().uri("/v1/articles/infinite-scroll?boardId=1&pageSize=30&lastArticleId={lastArticleId}", lastArticleId)
+                .retrieve().body(new ParameterizedTypeReference<List<ArticleResponse>>() {
+                });
+
+        secondPage.forEach(article -> {
+            log.info(article.toString());
+        });
     }
 
     @Getter

--- a/large-scale-board/service/article/src/test/java/april2nd/board/article/repository/ArticleRepositoryTest.java
+++ b/large-scale-board/service/article/src/test/java/april2nd/board/article/repository/ArticleRepositoryTest.java
@@ -8,7 +8,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 import java.util.List;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 @Slf4j
@@ -31,5 +31,17 @@ class ArticleRepositoryTest {
 
         assertNotNull(count);
         assertThat(count).isEqualTo(10000L);
+    }
+
+    @Test
+    void findInfiniteScrollTest() {
+        List<Article> articles = articleRepository.findAllInfiniteScroll(1L, 30L);
+
+        Long lastArticleId = articles.getLast().getArticleId();
+
+        var result = articleRepository.findAllInfiniteScroll(1L, 30L, lastArticleId);
+
+        assertNotNull(result);
+        assertThat(result).hasSize(30);
     }
 }


### PR DESCRIPTION
<b> 무한 스크롤 API 구현
> 요청 파라미터
  - boardId : 게시판 아이디
  - pageSize : 한번 호출에 조회할 게시글 개수
  - lastArticleId(optional) : 마지막으로 조회한 게시물 번호 
